### PR TITLE
Fix babel errors on start

### DIFF
--- a/examples/follower-graph/package.json
+++ b/examples/follower-graph/package.json
@@ -35,5 +35,8 @@
     "react": "^15.0.0",
     "react-datascript": "^0.3.0",
     "react-dom": "^15.0.1"
-  }
+  },
+ "babel": {
+   "presets": [ "es2015", "react" ] 
+ }
 }


### PR DESCRIPTION
Couldn't find preset es2015 relative to directory after `npm install` and `npm start` following directions in README