### PR TITLE
docs: SMOKE2 — exercise Slack-post path

### DIFF
--- a/SMOKE2.md
+++ b/SMOKE2.md
@@ -1,0 +1,3 @@
+# SMOKE 2
+
+Second merge to exercise the Slack-post path under the temporary always-flag prompt override.


### PR DESCRIPTION
Second smoke: hook is currently PATCHed to always flag a synthetic concern. Expecting a Slack message in #bot-chat after merge.