### PR TITLE
docs: SMOKE3 — post-fix sre-sweep verification

### DIFF
--- a/SMOKE3.md
+++ b/SMOKE3.md
@@ -1,0 +1,3 @@
+# SMOKE 3 (post-flamecast-fix)
+
+Third smoke after flamecast PR #11 merged. Verifying GitHub→hook.new→flamecast→Slack still works post-rename and post-PScale migration.


### PR DESCRIPTION
Tiny doc add to re-verify the sre-sweep pipeline end-to-end after flamecast PR #11 merged. Expecting cloud-claude think to return 'ok' on this benign diff and the hook to skip Slack.